### PR TITLE
PR: Generalize plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# lektor-tipue-search
+# lektor-static-search
 
 > This is under development
 
-This is a plugin for Lektor that adds support for [tipue search](http://www.tipue.com/search/) to projects. When enabled it can generate json files in the `tipue-search/` folder automatically when the server (or build process) is run with the `-f tipue` flag.
+This is a plugin for Lektor that adds support for static search to projects. When enabled it can generate json files in the `static-search/` folder automatically when the server (or build process) is run with the `-f static-search` flag.
+
+This json files can be used with js libraries like [Tipue search](http://www.tipue.com/search/) or [Lurn.js](http://lunrjs.com/).
 
 ## Enabling the Plugin
 
@@ -11,21 +13,21 @@ This is a plugin for Lektor that adds support for [tipue search](http://www.tipu
 ```bash
 mkdir papckages
 cd packages
-git clone git@github.com:rlaverde/lektor-tipue-search.git
+git clone git@github.com:rlaverde/lektor-static-search.git
 ```
 
 ## Configurations
 
 There are some globals configurations:
 
-`configs/tipue-search.ini:`
+`configs/static-search.ini:`
 
-    output_directory = tipue_search
+    output_directory = static_search
 
 
 Also you should add an entry for any model that you want to be generated into de json file (it should start by `model`)
 
-`configs/tipue-search.ini:`
+`configs/static-search.ini:`
 
 ```ini
 [model.blog-post]
@@ -58,7 +60,7 @@ choices = some_tag, another_tag
 
 and will generate a json file (for each alternative):
 
-`tipue_search/tipue_search_en.ini:`
+`static_search/static_search_en.ini:`
 
 ```json
 [{"url": "/blog/example",
@@ -72,5 +74,5 @@ and will generate a json file (for each alternative):
 ## Usage
 
 ```bash
-lektor build -f tipue
+lektor build -f static-search
 ```

--- a/lektor_static_search.py
+++ b/lektor_static_search.py
@@ -8,16 +8,16 @@ from lektor.pluginsystem import Plugin
 from lektor.db import Page
 
 
-class TipueSearchPlugin(Plugin):
-    name = u'Lektor Tipue Search'
-    description = u'Serialize models contents for using tipue search.'
+class StaticSearchPlugin(Plugin):
+    name = u'Lektor Static Search'
+    description = u'Serialize models contents for using with static search js libraries.'
 
     def __init__(self, *args, **kwargs):
         Plugin.__init__(self, *args, **kwargs)
-        self.tipue_search = defaultdict(list)
+        self.static_search = defaultdict(list)
         self.enabled = False
         self.models = None
-        self.options = {'output_path': 'tipue-search', }
+        self.options = {'output_path': 'static-search', }
 
     def check_enabled(func):
         def func_wrapper(self, *args, **kwargs):
@@ -30,7 +30,7 @@ class TipueSearchPlugin(Plugin):
     def on_server_spawn(self, **extra):
         extra_flags = extra.get("extra_flags") \
                       or extra.get("build_flags") or {}
-        self.enabled = bool(extra_flags.get('tipue'))
+        self.enabled = bool(extra_flags.get('static-search'))
 
     def on_setup_env(self, **extra):
         self.models = defaultdict(dict)
@@ -51,7 +51,7 @@ class TipueSearchPlugin(Plugin):
 
     @check_enabled
     def on_before_build_all(self, builder, **extra):
-        self.tipue_search.clear()
+        self.static_search.clear()
 
         output_path = os.path.join(builder.env.root_path,
                                    self.options['output_path'])
@@ -68,14 +68,14 @@ class TipueSearchPlugin(Plugin):
                 item = {key: source[field] for key, field in model.items()}
                 item['url'] = source.url_path
 
-                self.tipue_search[source.alt].append(item)
+                self.static_search[source.alt].append(item)
 
     @check_enabled
     def on_after_build_all(self, builder, **extra):
-        for alt, pages in self.tipue_search.items():
+        for alt, pages in self.static_search.items():
             filename = os.path.join(builder.env.root_path,
                                     self.options['output_path'],
-                                    'tipue_search_{}.json'.format(alt))
+                                    'static_search_{}.json'.format(alt))
 
             try:
                 with open(filename, 'r') as f:
@@ -87,5 +87,5 @@ class TipueSearchPlugin(Plugin):
                 with open(filename, 'w') as f:
                     f.write(json.dumps(pages))
 
-                reporter.report_generic('generated tipue search file{}'.format(
+                reporter.report_generic('generated static search file{}'.format(
                     filename))

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,15 @@
 from setuptools import setup
 
 setup(
-    name='lektor-tipue-search',
+    name='lektor-static-search',
     version='0.1',
     author=u'Rafael Laverde,,,',
     author_email='leafar91@gmail.com',
     license='MIT',
-    py_modules=['lektor_tipue_search'],
+    py_modules=['lektor_static_search'],
     entry_points={
         'lektor.plugins': [
-            'tipue-search = lektor_tipue_search:TipueSearchPlugin',
+            'static-search = lektor_static_search:StaticSearchPlugin',
         ]
     }
 )


### PR DESCRIPTION
The plugin should depend on Tipue and instead be more generic.

- Change name to lektor-static-search.
- Add reference to tipue and lunrjs in the Readme.
- Delete references to tipue in the code and settings.